### PR TITLE
Fix individual errors codes to be more representative

### DIFF
--- a/lib/locale/en.yml
+++ b/lib/locale/en.yml
@@ -1,9 +1,8 @@
 en:
   errors:
     messages:
-      default: Not a valid URL
-      host: A host and scheme (ex. 'http://adgear.com') are required
-      suffix: A valid public suffix (.com, .org, ...) is required
-      no_local: Local paths are not allowed
-      scheme: Must begin with 'http://' or 'https://'
-      path: A path ('/') is required before a query ('?')
+      url: is not a valid URL
+      url_host: requires valid host
+      url_suffix: requires valid public suffix (.com, .org, ...)
+      url_scheme: "requires scheme in: %{schemes}"
+      url_path: requires explicit path ('/') when query is specified ('?')

--- a/spec/validate_url_spec.rb
+++ b/spec/validate_url_spec.rb
@@ -83,10 +83,10 @@ describe "URL validation" do
        expect(@user).not_to be_valid
     end
 
-    it "should return a default error message" do
+    it "should return multiple error messages" do
       @user.homepage = "invalid"
-      error_message = "A host and scheme (ex. 'http://adgear.com') are required", "Must begin with 'http://' or 'https://'"
-      @user.valid?
+      error_message = ["requires valid host", "requires scheme in: http, https"]
+      expect(@user).not_to be_valid
       expect(@user.errors[:homepage]).to eq(error_message)
     end
 


### PR DESCRIPTION
- Prefix error messages with "url_" so it's more explicit those are related to url validation
- Extract errors addition logic into its own method 
- Fix schemes error message to print the permitted schemes list