### PR TITLE
Update validate_url.gemspec

### DIFF
--- a/validate_url.gemspec
+++ b/validate_url.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency(%q<activemodel>, [">= 3.0.0"])
   s.add_runtime_dependency(%q<addressable>, [">= 0"])
-  s.add_runtime_dependency(%q<public_suffix>, ["~> 2.x.x"])
+  s.add_runtime_dependency(%q<public_suffix>, [">= 2.0.0"])
   s.add_development_dependency(%q<rspec>, [">= 3.0.0"])
   s.add_development_dependency(%q<diff-lcs>, [">= 1.1.2"])
   s.add_development_dependency(%q<rake>)


### PR DESCRIPTION
I had some gem conflict issues where I needed public suffix at version 3